### PR TITLE
Backwards-compatible for item damage directive

### DIFF
--- a/DnDGen.Web/wwwroot/js/treasure/item.directive.js
+++ b/DnDGen.Web/wwwroot/js/treasure/item.directive.js
@@ -28,7 +28,7 @@
                     || scope.item.magic.curse.length
                     || scope.item.totalArmorBonus
                     || scope.item.damage
-                    || scope.item.damages.length
+                    || (scope.item.damages && scope.item.damages.length)
                     || scope.item.magic.intelligence.ego;
             }
         }

--- a/DnDGen.Web/wwwroot/templates/treasure/item.html
+++ b/DnDGen.Web/wwwroot/templates/treasure/item.html
@@ -78,10 +78,9 @@
                     <ul>
                         <li>Size: {{item.size}}</li>
                         <li>Combat Types: {{item.combatTypes.join(", ")}}</li>
-                        <li>Damage: {{item.damage}}</li>
-                        <li>Damage Type: {{item.damageType}}</li>
-                        <li>Threat Range: {{item.threatRange}}</li>
-                        <li>Critical Multiplier: {{item.criticalMultiplier}}</li>
+                        <li ng-if="item.damage">Damage: {{item.damage}} {{item.damageType}}</li>
+                        <li ng-if="item.damageDescription">Damage: {{item.damageDescription}}</li>
+                        <li>Critical: {{item.threatRangeDescription ? item.threatRangeDescription : item.threatRange}} ({{item.criticalMultiplier}})</li>
                         <li ng-show="item.ammunition">Ammunition Used: {{item.ammunition}}</li>
                     </ul>
                 </dndgen-collapsable-list>

--- a/DnDGen.Web/wwwroot/templates/treasure/treasure.html
+++ b/DnDGen.Web/wwwroot/templates/treasure/treasure.html
@@ -2,16 +2,12 @@
     <span ng-show="treasure.coin.quantity > 0">{{treasure.coin.quantity | number}} {{treasure.coin.currency}}</span>
     <dndgen-collapsable-list ng-show="treasure.goods.length > 0" heading="Goods" has-list="treasure.goods.length > 0">
         <ul>
-            <li ng-repeat="good in treasure.goods track by $index">
-                {{good.description}} ({{good.valueInGold | number}}gp)
-            </li>
+            <li ng-repeat="good in treasure.goods track by $index">{{good.description}} ({{good.valueInGold | number}}gp)</li>
         </ul>
     </dndgen-collapsable-list>
     <dndgen-collapsable-list ng-show="treasure.items.length > 0" heading="Items" has-list="treasure.items.length > 0">
         <ul>
-            <li ng-repeat="item in treasure.items track by $index">
-                <dndgen-item item="item"></dndgen-item>
-            </li>
+            <li ng-repeat="item in treasure.items track by $index"><dndgen-item item="item"></dndgen-item></li>
         </ul>
     </dndgen-collapsable-list>
 </div>


### PR DESCRIPTION
#1988 

Items from the API have a different structure. The directive needs to handle both old and new.